### PR TITLE
Fix duplicate About Us link

### DIFF
--- a/agency/src/Header.js
+++ b/agency/src/Header.js
@@ -66,15 +66,6 @@ const Header = () => {
   >
     About&nbsp;Us
   </NavLink>
-  <NavLink
-    to="/about"
-    onClick={closeMenu}
-    className={({ isActive }) =>
-      `header__nav-link ${isActive ? '--active' : ''}`
-    }
-  >
-    About&nbsp;Us
-  </NavLink>
 
   <Dropdown label="TeacherSection">
     <Dropdown.Item to="/admin" onClick={closeMenu}>


### PR DESCRIPTION
## Summary
- remove the repeated "About Us" link from `Header`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684016037ab88331a069a0226c14c650